### PR TITLE
Update Orders.php

### DIFF
--- a/includes/classes/Feature/WooCommerce/Orders.php
+++ b/includes/classes/Feature/WooCommerce/Orders.php
@@ -21,6 +21,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Orders {
 	/**
+	 * The name of the index;
+	 *
+	 * @var string
+	 */
+	private $index;
+	
+	/**
 	 * Initialize feature.
 	 *
 	 * @return void


### PR DESCRIPTION
Fixes a deprecation notice because the `index` property is undeclared and created dynamically.
